### PR TITLE
Optimize font loading

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -18,18 +18,6 @@ export default class MyApp extends App {
     return (
       <>
         <Head>
-          <meta charSet="utf-8" />
-          <meta httpEquiv="x-ua-compatible" content="ie=edge" />
-          <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1, shrink-to-fit=no"
-          />
-
-          <link
-            href="https://fonts.googleapis.com/css?family=Old+Standard+TT:400,400i,700"
-            rel="stylesheet"
-          />
-
           <title>{`${siteTitle}${title ? ` ・ ${title}` : ''}`}</title>
         </Head>
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,45 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head>
+          <meta charSet="utf-8" />
+          <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+          <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, shrink-to-fit=no"
+          />
+
+          {/* Code snippet to speed up Google Fonts rendering: googlefonts.3perf.com */}
+          <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin="anonymous"
+          />
+          <link
+            rel="preload"
+            href="https://fonts.googleapis.com/css?family=Old+Standard+TT:400,400i,700"
+            as="fetch"
+            crossOrigin="anonymous"
+          />
+          <script
+            type="text/javascript"
+            dangerouslySetInnerHTML={{
+              __html: `
+            !function(e,n,t){"use strict";var o="https://fonts.googleapis.com/css?family=Old+Standard+TT:400,400i,700",r="__3perf_googleFontsStylesheet";function c(e){(n.head||n.body).appendChild(e)}function a(){var e=n.createElement("link");e.href=o,e.rel="stylesheet",c(e)}function f(e){if(!n.getElementById(r)){var t=n.createElement("style");t.id=r,c(t)}n.getElementById(r).innerHTML=e}e.FontFace&&e.FontFace.prototype.hasOwnProperty("display")?(t[r]&&f(t[r]),fetch(o).then(function(e){return e.text()}).then(function(e){return e.replace(/@font-face {/g,"@font-face{font-display:swap;")}).then(function(e){return t[r]=e}).then(f).catch(a)):a()}(window,document,localStorage);
+            `,
+            }}
+          />
+          {/* Code snippet to speed up Google Fonts rendering: googlefonts.3perf.com */}
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@ import Wrapper from '../src/components/wrapper'
 
 import * as spacings from '../src/theme/spacings'
 import * as colors from '../src/theme/colors'
+import * as typography from '../src/theme/typography'
 
 const introPseudoElement = `
   position: absolute;
@@ -11,7 +12,8 @@ const introPseudoElement = `
 
   padding: 0 ${spacings.small};
 
-  font-family: 'Harman Simple';
+  font-family: ${typography.harmanSimple};
+  font-weight: normal;
   font-size: 1rem;
 
   white-space: nowrap;

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -2,8 +2,11 @@ import PropTypes from 'prop-types'
 import Link from 'next/link'
 
 import Wrapper from '../wrapper'
+
 import * as spacings from '../../theme/spacings'
 import * as colors from '../../theme/colors'
+import * as typography from '../../theme/typography'
+
 import { title } from '../../../site'
 
 const LinkWithPrefetch = ({ children, ...rest }) => (
@@ -99,7 +102,7 @@ const Header = () => (
 
       h1 {
         margin: 0;
-        font-family: 'Harman Retro';
+        font-family: ${typography.harmanRetro};
         font-size: inherit;
         color: ${colors.primary};
       }

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -2,7 +2,8 @@
   font-family: 'Harman Retro';
   font-weight: 400;
   font-style: normal;
-  src: local('Harman Retro'),
+  font-display: swap;
+  src: local('Harman Retro'), local('Harman-Retro'),
     url('/static/fonts/harman-retro.woff') format('woff'),
     url('/static/fonts/harman-retro.woff2') format('woff2');
 }
@@ -11,7 +12,8 @@
   font-family: 'Harman Retro Inline';
   font-weight: 700;
   font-style: normal;
-  src: local('Harman Retro Inline'), local('Harman-Retro-Inline'),
+  font-display: swap;
+  src: local('Harman Retro Inline'), local('Harman-RetroInline'),
     url('/static/fonts/harman-retro-inline.woff') format('woff'),
     url('/static/fonts/harman-retro-inline.woff2') format('woff2');
 }
@@ -20,6 +22,7 @@
   font-family: 'Harman Simple';
   font-weight: 700;
   font-style: normal;
+  font-display: swap;
   src: local('Harman Simple'), local('Harman-Simple'),
     url('/static/fonts/harman-simple.woff') format('woff'),
     url('/static/fonts/harman-simple.woff2') format('woff2');

--- a/src/styles/reset.js
+++ b/src/styles/reset.js
@@ -1,5 +1,7 @@
 import css from 'styled-jsx/css'
+
 import * as colors from '../theme/colors'
+import * as typography from '../theme/typography'
 
 const reset = css.global`
   * {
@@ -18,7 +20,7 @@ const reset = css.global`
     background-size: 100px 100px;
     background-blend-mode: multiply;
 
-    font-family: 'Old Standard TT', Georgia, 'Times New Roman', Times, serif;
+    font-family: ${typography.oldStandardTT};
     font-size: 16px;
   }
 
@@ -37,7 +39,7 @@ const reset = css.global`
   }
 
   h1 {
-    font-family: 'Harman Retro Inline';
+    font-family: ${typography.harmanRetroInline};
     font-size: 3em;
     letter-spacing: -0.05em;
   }

--- a/src/theme/typography.js
+++ b/src/theme/typography.js
@@ -1,0 +1,5 @@
+export const oldStandardTT = `'Old Standard TT', Georgia, 'Times New Roman', Times, serif`
+
+export const harmanSimple = `'Harman Simple', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;`
+export const harmanRetro = `'Harman Retro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;`
+export const harmanRetroInline = `'Harman Retro Inline', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif`


### PR DESCRIPTION
Add `font-display: swap` to display fallback font while loading the web
font. This improves time to first paint.

Also includes a little refactor of font names to a typography theme
file.